### PR TITLE
fix: ignore synthetic gitleaks findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,4 @@
+453b194527b09fdca34c55535592a8e20cc34df0:evaluator/mcp_client.py:generic-api-key:121
+4dccb4f08c1f45fb96a9684f3e8abfaf6dbd21a9:docs/api.md:curl-auth-header:54
+797446fadce3b2a077d1de3f733b4d45b33d9b5d:prompts.yaml:generic-api-key:34
+c7dac932c4815a0d54aad61a408213d9c613a834:tests/test_evaluator.py:generic-api-key:28


### PR DESCRIPTION
## Summary
- Adds a .gitleaksignore baseline for the four historical synthetic evaluator/documentation findings that broke the scheduled Supply Chain Audit.
- Keeps the fix scoped to exact historical fingerprints instead of broad file/path allowlisting.

## Verification
- gitleaks detect --redact -v --exit-code=2
- pip-audit -r requirements.txt
- Python hash pinning check
- GitHub Actions SHA pinning check
- uv run python -m pytest

Root cause: the new scheduled Supply Chain Audit scans full git history with gitleaks. It found synthetic security-evaluator fixtures and an API docs placeholder, not live credentials.