### PR TITLE
fix(ci): use supported Codecov files input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Summary
- replace the removed Codecov Action `file` input with the supported `files` input
- preserve the explicit `coverage.xml` upload and existing non-fatal upload behavior

## Root cause
The workflow was upgraded to `codecov/codecov-action` v7 while retaining the legacy singular `file` input. The pinned action metadata exposes `files`, so every matrix job completed successfully but emitted an `Unexpected input(s) 'file'` annotation.

## Verification
- reproduced the warning condition with a targeted assertion before the change
- verified the assertion passes after the change
- parsed `.github/workflows/ci.yml` successfully as YAML
- `git diff --check` passes